### PR TITLE
Introduce session concept to isolate targets

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "manifest_version": 2,
   "description": "",
-  "homepage_url": "https://remotedebug.org",
+  "homepage_url": "https://devtoolsremote.com",
   "browser_action": {
       "default_icon": "icons/icon128.png",
       "default_title": "DevTools-Remote"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "express": "^4.12.3",
     "guid": "0.0.12",
+    "node-uuid": "^1.4.7",
     "socket.io": "^1.3.5",
     "winston": "^1.0.0",
     "ws": "yarax/ws"


### PR DESCRIPTION
Introduce session-concept, where a sessionId is generated after hello-handshake, in order to isolate debugging targets by sessionId.
### Changes
- Generate sessionId on `hello`
- Store debugging targets by sesssionId
- Allow multiple debugging targets per session
  `Remove generic`/json`endpoint
  ` Add `/<session>/json` endpoint to get targets for a given session
